### PR TITLE
spacing in file uri

### DIFF
--- a/as-ead-pdf.xsl
+++ b/as-ead-pdf.xsl
@@ -18,6 +18,16 @@
         *                                                                 *
         *******************************************************************
     -->
+
+    <!--
+       MODIFIED for Harvard's use by Bobbi Fox  31 October 2018
+     - Reformatted to enhance readability
+     - See comments with FOX preceding them for differences
+
+     Backported + reconciled from 3.1.0 on 2021-09-24
+    -->
+    
+
     <xsl:output method="xml" encoding="utf-8" indent="yes"/>
 
     <!-- Calls a stylesheet with local functions and lookup lists for languages and subject authorities -->

--- a/as-ead-pdf.xsl
+++ b/as-ead-pdf.xsl
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ns2="http://www.w3.org/1999/xlink"
-    xmlns:local="http://www.yoursite.org/namespace" xmlns:ead="urn:isbn:1-931666-22-9"
-    xmlns:fo="http://www.w3.org/1999/XSL/Format" version="2.0" exclude-result-prefixes="#all">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:ns2="http://www.w3.org/1999/xlink" xmlns:local="http://www.yoursite.org/namespace"
+    xmlns:ead="urn:isbn:1-931666-22-9" xmlns:fo="http://www.w3.org/1999/XSL/Format" version="2.0"  exclude-result-prefixes="#all">
     <!--
         *******************************************************************
         *                                                                 *
@@ -19,18 +18,14 @@
         *                                                                 *
         *******************************************************************
     -->
-    <!--
-         MODIFIED for Harvard's use by Bobbi Fox  31 October 2018
-	 - Reformatted to enhance readability
-	 - See comments with FOX preceding them for differences
-    -->
-
     <xsl:output method="xml" encoding="utf-8" indent="yes"/>
 
     <!-- Calls a stylesheet with local functions and lookup lists for languages and subject authorities -->
     <xsl:include href="as-helper-functions.xsl"/>
 
     <xsl:strip-space elements="*"/>
+    <xsl:param name="pdf_image"/>
+
 
     <!-- The following attribute sets are reusable styles used throughout the stylesheet. -->
     <!-- Headings -->
@@ -68,24 +63,16 @@
 
     <!-- Headings with id attribute -->
     <xsl:attribute-set name="h1ID" use-attribute-sets="h1">
-        <xsl:attribute name="id">
-            <xsl:value-of select="local:buildID(.)"/>
-        </xsl:attribute>
+        <xsl:attribute name="id"><xsl:value-of select="local:buildID(.)"/></xsl:attribute>
     </xsl:attribute-set>
     <xsl:attribute-set name="h2ID" use-attribute-sets="h2">
-        <xsl:attribute name="id">
-            <xsl:value-of select="local:buildID(.)"/>
-        </xsl:attribute>
+        <xsl:attribute name="id"><xsl:value-of select="local:buildID(.)"/></xsl:attribute>
     </xsl:attribute-set>
     <xsl:attribute-set name="h3ID" use-attribute-sets="h3">
-        <xsl:attribute name="id">
-            <xsl:value-of select="local:buildID(.)"/>
-        </xsl:attribute>
+        <xsl:attribute name="id"><xsl:value-of select="local:buildID(.)"/></xsl:attribute>
     </xsl:attribute-set>
     <xsl:attribute-set name="h4ID" use-attribute-sets="h4">
-        <xsl:attribute name="id">
-            <xsl:value-of select="local:buildID(.)"/>
-        </xsl:attribute>
+        <xsl:attribute name="id"><xsl:value-of select="local:buildID(.)"/></xsl:attribute>
     </xsl:attribute-set>
 
     <!-- Linking attributes styles -->
@@ -134,26 +121,23 @@
 
     <!--  Start main page design and layout -->
     <xsl:template match="/">
-        <fo:root xmlns:fo="http://www.w3.org/1999/XSL/Format" font-size="12pt" font-family="serif">
+        <fo:root xmlns:fo="http://www.w3.org/1999/XSL/Format" font-size="12pt" font-family="KurintoText,KurintoTextJP,KurintoTextKR,KurintoTextSC,NotoSerif">
             <!-- Set up page types and page layouts -->
             <fo:layout-master-set>
                 <!-- Page master for Cover Page -->
-                <fo:simple-page-master master-name="cover-page" page-width="8.5in"
-                    page-height="11in" margin="0.5in">
+                <fo:simple-page-master master-name="cover-page" page-width="8.5in" page-height="11in" margin="0.5in">
                     <fo:region-body margin="0.5in 0.5in 1in 0.5in"/>
                     <fo:region-before extent="0.2in"/>
                     <fo:region-after extent="2in"/>
                 </fo:simple-page-master>
                 <!-- Page master for Table of Contents -->
-                <fo:simple-page-master master-name="toc" page-width="8.5in" page-height="11in"
-                    margin="0.5in">
+                <fo:simple-page-master master-name="toc" page-width="8.5in" page-height="11in" margin="0.5in">
                     <fo:region-body margin-top="0.25in" margin-bottom="0.25in"/>
                     <fo:region-before extent="0.5in"/>
                     <fo:region-after extent="0.2in"/>
                 </fo:simple-page-master>
                 <!-- Page master for Finding Aid Contents -->
-                <fo:simple-page-master master-name="contents" page-width="8.5in" page-height="11in"
-                    margin="0.5in">
+                <fo:simple-page-master master-name="contents" page-width="8.5in" page-height="11in" margin="0.5in">
                     <fo:region-body margin-top="0.25in" margin-bottom="0.25in"/>
                     <fo:region-before extent="0.5in"/>
                     <fo:region-after extent="0.2in"/>
@@ -165,15 +149,12 @@
             <!-- Cover page layout -->
             <fo:page-sequence master-reference="cover-page">
                 <xsl:if test="/ead:ead/ead:eadheader/ead:filedesc/ead:publicationstmt">
-                    <fo:static-content flow-name="xsl-region-after">
-                        <xsl:apply-templates
-                            select="/ead:ead/ead:eadheader/ead:filedesc/ead:publicationstmt"
-                            mode="coverPage"/>
+                  <fo:static-content flow-name="xsl-region-after">
+                        <xsl:apply-templates select="/ead:ead/ead:eadheader/ead:filedesc/ead:publicationstmt" mode="coverPage"/>
                     </fo:static-content>
-                </xsl:if>
+               </xsl:if>
                 <fo:flow flow-name="xsl-region-body">
-                    <xsl:apply-templates select="/ead:ead/ead:eadheader/ead:filedesc/ead:titlestmt"
-                        mode="coverPage"/>
+                    <xsl:apply-templates select="/ead:ead/ead:eadheader/ead:filedesc/ead:titlestmt" mode="coverPage"/>
                 </fo:flow>
             </fo:page-sequence>
             <!-- Table of Contents layout -->
@@ -181,9 +162,7 @@
                 <!-- Page header -->
                 <fo:static-content flow-name="xsl-region-before" margin-top=".15in">
                     <fo:block color="dimgray" font-size="10pt" text-align="center">
-                        <xsl:apply-templates
-                            select="ead:ead/ead:eadheader/ead:filedesc/ead:titlestmt"
-                            mode="pageHeader"/>
+                        <xsl:apply-templates select="ead:ead/ead:eadheader/ead:filedesc/ead:titlestmt" mode="pageHeader"/>
                     </fo:block>
                 </fo:static-content>
                 <!-- Page footer-->
@@ -204,9 +183,7 @@
                 <!-- Page header -->
                 <fo:static-content flow-name="xsl-region-before" margin-top=".15in">
                     <fo:block color="dimgray" font-size="10pt" text-align="center">
-                        <xsl:apply-templates
-                            select="ead:ead/ead:eadheader/ead:filedesc/ead:titlestmt"
-                            mode="pageHeader"/>
+                        <xsl:apply-templates select="ead:ead/ead:eadheader/ead:filedesc/ead:titlestmt" mode="pageHeader"/>
                     </fo:block>
                 </fo:static-content>
                 <!-- Page footer-->
@@ -228,9 +205,7 @@
     <!-- Named template to link back to the table of contents  -->
     <xsl:template name="toc">
         <fo:block font-size="11pt" margin-top="12pt" margin-bottom="18pt">
-            <fo:basic-link text-decoration="none" internal-destination="toc" color="#0D6CB6"
-                    ><fo:inline font-weight="bold">^</fo:inline> Return to Table of Contents
-            </fo:basic-link>
+            <fo:basic-link text-decoration="none" internal-destination="toc" color="#0D6CB6"><fo:inline font-weight="bold">^</fo:inline> Return to Table of Contents </fo:basic-link>
         </fo:block>
     </xsl:template>
 
@@ -239,8 +214,8 @@
     <xsl:template match="ead:titlestmt" mode="pageHeader">
         <!-- Uses filing type title if present -->
         <xsl:choose>
-            <xsl:when test="ead:titleproper[@type = 'filing']">
-                <xsl:apply-templates select="ead:titleproper[@type = 'filing']"/>
+            <xsl:when test="ead:titleproper[@type='filing']">
+                <xsl:apply-templates select="ead:titleproper[@type='filing']"/>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:apply-templates select="ead:titleproper[1]"/>
@@ -253,8 +228,8 @@
         <fo:block border-bottom="1pt solid #666" margin-top="1in" id="cover-page">
             <fo:block xsl:use-attribute-sets="h1">
                 <xsl:choose>
-                    <xsl:when test="ead:titleproper[@type = 'filing']">
-                        <xsl:apply-templates select="ead:titleproper[@type = 'filing']"/>
+                    <xsl:when test="ead:titleproper[@type='filing']">
+                        <xsl:apply-templates select="ead:titleproper[@type='filing']"/>
                     </xsl:when>
                     <xsl:otherwise>
                         <xsl:apply-templates select="ead:titleproper[1]"/>
@@ -262,11 +237,9 @@
                 </xsl:choose>
             </fo:block>
             <xsl:if test="ead:subtitle">
-                <fo:block font-size="16" font-weight="bold">
-                    <xsl:apply-templates select="ead:subtitle"/>
-                </fo:block>
+                <fo:block font-size="16" font-weight="bold"><xsl:apply-templates select="ead:subtitle"/></fo:block>
             </xsl:if>
-<!-- FOX: display the sponsor -->
+            <!-- FOX: display the sponsor -->
             <xsl:if test="ead:sponsor">
                 <fo:block font-size="12">
                     <xsl:apply-templates select="ead:sponsor"/>
@@ -290,13 +263,9 @@
         </fo:block>
     </xsl:template>
     <xsl:template match="ead:profiledesc/child::*">
-        <fo:block>
-            <xsl:apply-templates/>
-        </fo:block>
+        <fo:block><xsl:apply-templates/></fo:block>
     </xsl:template>
-    <xsl:template match="ead:profiledesc/ead:language">
-        <xsl:value-of select="."/>
-    </xsl:template>
+    <xsl:template match="ead:profiledesc/ead:language"> <xsl:value-of select="."/></xsl:template>
     <xsl:template match="ead:profiledesc/ead:creation/ead:date">
         <!--
             Uses local function to format date into Month, day year.
@@ -311,10 +280,15 @@
         i.e. src="myicon.png"
     -->
     <xsl:template name="icon">
-        <fo:block text-align="left" margin-left="-.75in" margin-top="-.5in">
-            <fo:external-graphic src="archivesspace.small.png" content-height="75%"
-                content-width="75%"/>
+      <fo:block-container max-width="6.5in" max-height="4in">
+        <fo:block text-align="left">
+            <fo:external-graphic content-width="scale-down-to-fit"
+              content-height="scale-down-to-fit" width="100%" height="100%"
+              scaling="uniform">
+              <xsl:attribute name="src"><xsl:value-of select="$pdf_image"/></xsl:attribute>
+            </fo:external-graphic>
         </fo:block>
+      </fo:block-container>
     </xsl:template>
 
     <!-- Generates PDF Bookmarks -->
@@ -325,47 +299,35 @@
             </fo:bookmark>
             <xsl:if test="ead:did">
                 <fo:bookmark internal-destination="{local:buildID(ead:did)}">
-                    <fo:bookmark-title>
-                        <xsl:value-of select="local:tagName(ead:did)"/>
-                    </fo:bookmark-title>
+                    <fo:bookmark-title><xsl:value-of select="local:tagName(ead:did)"/></fo:bookmark-title>
                 </fo:bookmark>
             </xsl:if>
             <xsl:if test="ead:bioghist">
                 <fo:bookmark internal-destination="{local:buildID(ead:bioghist[1])}">
-                    <fo:bookmark-title>
-                        <xsl:value-of select="local:tagName(ead:bioghist[1])"/>
-                    </fo:bookmark-title>
+                    <fo:bookmark-title><xsl:value-of select="local:tagName(ead:bioghist[1])"/></fo:bookmark-title>
                 </fo:bookmark>
             </xsl:if>
             <xsl:if test="ead:scopecontent">
                 <fo:bookmark internal-destination="{local:buildID(ead:scopecontent[1])}">
-                    <fo:bookmark-title>
-                        <xsl:value-of select="local:tagName(ead:scopecontent[1])"/>
-                    </fo:bookmark-title>
+                    <fo:bookmark-title><xsl:value-of select="local:tagName(ead:scopecontent[1])"/></fo:bookmark-title>
                 </fo:bookmark>
             </xsl:if>
             <xsl:if test="ead:arrangement">
                 <fo:bookmark internal-destination="{local:buildID(ead:arrangement[1])}">
-                    <fo:bookmark-title>
-                        <xsl:value-of select="local:tagName(ead:arrangement[1])"/>
-                    </fo:bookmark-title>
+                    <fo:bookmark-title><xsl:value-of select="local:tagName(ead:arrangement[1])"/></fo:bookmark-title>
                 </fo:bookmark>
             </xsl:if>
             <xsl:if test="ead:fileplan">
                 <fo:bookmark internal-destination="{local:buildID(ead:fileplan[1])}">
-                    <fo:bookmark-title>
-                        <xsl:value-of select="local:tagName(ead:fileplan[1])"/>
-                    </fo:bookmark-title>
+                    <fo:bookmark-title><xsl:value-of select="local:tagName(ead:fileplan[1])"/></fo:bookmark-title>
                 </fo:bookmark>
             </xsl:if>
 
             <!-- Administrative Information  -->
-            <xsl:if
-                test="
-                    ead:accessrestrict or ead:userestrict or
-                    ead:custodhist or ead:accruals or ead:altformavail or ead:acqinfo or
-                    ead:processinfo or ead:appraisal or ead:originalsloc or
-                    /ead:ead/ead:eadheader/ead:filedesc/ead:publicationstmt or /ead:ead/ead:eadheader/ead:revisiondesc">
+            <xsl:if test="ead:accessrestrict or ead:userestrict or
+                ead:custodhist or ead:accruals or ead:altformavail or ead:acqinfo or
+                ead:processinfo or ead:appraisal or ead:originalsloc or
+                /ead:ead/ead:eadheader/ead:filedesc/ead:publicationstmt or /ead:ead/ead:eadheader/ead:revisiondesc">
                 <fo:bookmark internal-destination="adminInfo">
                     <fo:bookmark-title>Administrative Information</fo:bookmark-title>
                 </fo:bookmark>
@@ -380,44 +342,32 @@
 
             <xsl:if test="ead:controlaccess">
                 <fo:bookmark internal-destination="{local:buildID(ead:controlaccess[1])}">
-                    <fo:bookmark-title>
-                        <xsl:value-of select="local:tagName(ead:controlaccess[1])"/>
-                    </fo:bookmark-title>
+                    <fo:bookmark-title><xsl:value-of select="local:tagName(ead:controlaccess[1])"/></fo:bookmark-title>
                 </fo:bookmark>
             </xsl:if>
             <xsl:if test="ead:otherfindaid">
                 <fo:bookmark internal-destination="{local:buildID(ead:otherfindaid[1])}">
-                    <fo:bookmark-title>
-                        <xsl:value-of select="local:tagName(ead:otherfindaid[1])"/>
-                    </fo:bookmark-title>
+                    <fo:bookmark-title><xsl:value-of select="local:tagName(ead:otherfindaid[1])"/></fo:bookmark-title>
                 </fo:bookmark>
             </xsl:if>
             <xsl:if test="ead:phystech">
                 <fo:bookmark internal-destination="{local:buildID(ead:phystech[1])}">
-                    <fo:bookmark-title>
-                        <xsl:value-of select="local:tagName(ead:phystech[1])"/>
-                    </fo:bookmark-title>
+                    <fo:bookmark-title><xsl:value-of select="local:tagName(ead:phystech[1])"/></fo:bookmark-title>
                 </fo:bookmark>
             </xsl:if>
             <xsl:if test="ead:odd">
                 <fo:bookmark internal-destination="{local:buildID(ead:odd[1])}">
-                    <fo:bookmark-title>
-                        <xsl:value-of select="local:tagName(ead:odd[1])"/>
-                    </fo:bookmark-title>
+                    <fo:bookmark-title><xsl:value-of select="local:tagName(ead:odd[1])"/></fo:bookmark-title>
                 </fo:bookmark>
             </xsl:if>
             <xsl:if test="ead:bibliography">
                 <fo:bookmark internal-destination="{local:buildID(ead:bibliography[1])}">
-                    <fo:bookmark-title>
-                        <xsl:value-of select="local:tagName(ead:bibliography[1])"/>
-                    </fo:bookmark-title>
+                    <fo:bookmark-title><xsl:value-of select="local:tagName(ead:bibliography[1])"/></fo:bookmark-title>
                 </fo:bookmark>
             </xsl:if>
             <xsl:if test="ead:index">
                 <fo:bookmark internal-destination="{local:buildID(ead:index[1])}">
-                    <fo:bookmark-title>
-                        <xsl:value-of select="local:tagName(ead:index[1])"/>
-                    </fo:bookmark-title>
+                    <fo:bookmark-title><xsl:value-of select="local:tagName(ead:index[1])"/></fo:bookmark-title>
                 </fo:bookmark>
             </xsl:if>
 
@@ -425,14 +375,11 @@
             <xsl:for-each select="ead:dsc">
                 <xsl:if test="child::*">
                     <fo:bookmark internal-destination="{local:buildID(.)}">
-                        <fo:bookmark-title>
-                            <xsl:value-of select="local:tagName(.)"/>
-                        </fo:bookmark-title>
+                        <fo:bookmark-title><xsl:value-of select="local:tagName(.)"/></fo:bookmark-title>
                     </fo:bookmark>
                 </xsl:if>
                 <!--Creates a submenu for collections, record groups and series and fonds-->
-                <xsl:for-each
-                    select="child::*[@level = 'collection'] | child::*[@level = 'recordgrp'] | child::*[@level = 'series'] | child::*[@level = 'fonds']">
+                <xsl:for-each select="child::*[@level = 'collection']  | child::*[@level = 'recordgrp']  | child::*[@level = 'series'] | child::*[@level = 'fonds']">
                     <fo:bookmark internal-destination="{local:buildID(.)}">
                         <fo:bookmark-title>
                             <xsl:choose>
@@ -446,8 +393,7 @@
                         </fo:bookmark-title>
                     </fo:bookmark>
                     <!-- Creates a submenu for subfonds, subgrp or subseries -->
-                    <xsl:for-each
-                        select="child::*[@level = 'subfonds'] | child::*[@level = 'subgrp'] | child::*[@level = 'subseries']">
+                    <xsl:for-each select="child::*[@level = 'subfonds'] | child::*[@level = 'subgrp']  | child::*[@level = 'subseries']">
                         <fo:bookmark internal-destination="{local:buildID(.)}">
                             <fo:bookmark-title>
                                 <xsl:choose>
@@ -473,9 +419,7 @@
             <fo:block xsl:use-attribute-sets="section">
                 <xsl:if test="ead:did">
                     <fo:block text-align-last="justify">
-                        <fo:basic-link internal-destination="{local:buildID(ead:did)}">
-                            <xsl:value-of select="local:tagName(ead:did)"/>
-                        </fo:basic-link>
+                        <fo:basic-link internal-destination="{local:buildID(ead:did)}"><xsl:value-of select="local:tagName(ead:did)"/></fo:basic-link>
                         <xsl:text>&#160;&#160;</xsl:text>
                         <fo:leader leader-pattern="dots"/>
                         <xsl:text>&#160;&#160;</xsl:text>
@@ -484,9 +428,7 @@
                 </xsl:if>
                 <xsl:if test="ead:bioghist">
                     <fo:block text-align-last="justify">
-                        <fo:basic-link internal-destination="{local:buildID(ead:bioghist[1])}">
-                            <xsl:value-of select="local:tagName(ead:bioghist[1])"/>
-                        </fo:basic-link>
+                        <fo:basic-link internal-destination="{local:buildID(ead:bioghist[1])}"><xsl:value-of select="local:tagName(ead:bioghist[1])"/></fo:basic-link>
                         <xsl:text>&#160;&#160;</xsl:text>
                         <fo:leader leader-pattern="dots"/>
                         <xsl:text>&#160;&#160;</xsl:text>
@@ -495,9 +437,7 @@
                 </xsl:if>
                 <xsl:if test="ead:scopecontent">
                     <fo:block text-align-last="justify">
-                        <fo:basic-link internal-destination="{local:buildID(ead:scopecontent[1])}">
-                            <xsl:value-of select="local:tagName(ead:scopecontent[1])"/>
-                        </fo:basic-link>
+                        <fo:basic-link internal-destination="{local:buildID(ead:scopecontent[1])}"><xsl:value-of select="local:tagName(ead:scopecontent[1])"/></fo:basic-link>
                         <xsl:text>&#160;&#160;</xsl:text>
                         <fo:leader leader-pattern="dots"/>
                         <xsl:text>&#160;&#160;</xsl:text>
@@ -506,9 +446,7 @@
                 </xsl:if>
                 <xsl:if test="ead:arrangement">
                     <fo:block text-align-last="justify">
-                        <fo:basic-link internal-destination="{local:buildID(ead:arrangement[1])}">
-                            <xsl:value-of select="local:tagName(ead:arrangement[1])"/>
-                        </fo:basic-link>
+                        <fo:basic-link internal-destination="{local:buildID(ead:arrangement[1])}"><xsl:value-of select="local:tagName(ead:arrangement[1])"/></fo:basic-link>
                         <xsl:text>&#160;&#160;</xsl:text>
                         <fo:leader leader-pattern="dots"/>
                         <xsl:text>&#160;&#160;</xsl:text>
@@ -517,9 +455,7 @@
                 </xsl:if>
                 <xsl:if test="ead:fileplan">
                     <fo:block text-align-last="justify">
-                        <fo:basic-link internal-destination="{local:buildID(ead:fileplan[1])}">
-                            <xsl:value-of select="local:tagName(ead:fileplan[1])"/>
-                        </fo:basic-link>
+                        <fo:basic-link internal-destination="{local:buildID(ead:fileplan[1])}"><xsl:value-of select="local:tagName(ead:fileplan[1])"/></fo:basic-link>
                         <xsl:text>&#160;&#160;</xsl:text>
                         <fo:leader leader-pattern="dots"/>
                         <xsl:text>&#160;&#160;</xsl:text>
@@ -528,27 +464,23 @@
                 </xsl:if>
 
                 <!-- Administrative Information  -->
-                <xsl:if
-                    test="
-                        ead:accessrestrict or ead:userestrict or
-                        ead:custodhist or ead:accruals or ead:altformavail or ead:acqinfo or
-                        ead:processinfo or ead:appraisal or ead:originalsloc or
-                        /ead:ead/ead:eadheader/ead:filedesc/ead:publicationstmt or /ead:ead/ead:eadheader/ead:revisiondesc">
-                    <fo:block text-align-last="justify">
-                        <fo:basic-link internal-destination="adminInfo">Administrative
-                            Information</fo:basic-link>
-                        <xsl:text>&#160;&#160;</xsl:text>
-                        <fo:leader leader-pattern="dots"/>
-                        <xsl:text>&#160;&#160;</xsl:text>
-                        <fo:page-number-citation ref-id="adminInfo"/>
-                    </fo:block>
+                <xsl:if test="ead:accessrestrict or ead:userestrict or
+                              ead:custodhist or ead:accruals or ead:altformavail or ead:acqinfo or
+                              ead:processinfo or ead:appraisal or ead:originalsloc or
+                              /ead:ead/ead:eadheader/ead:filedesc/ead:publicationstmt or /ead:ead/ead:eadheader/ead:revisiondesc">
+                        <fo:block text-align-last="justify">
+                            <fo:basic-link internal-destination="adminInfo">Administrative Information</fo:basic-link>
+                            <xsl:text>&#160;&#160;</xsl:text>
+                            <fo:leader leader-pattern="dots"/>
+                            <xsl:text>&#160;&#160;</xsl:text>
+                            <fo:page-number-citation ref-id="adminInfo"/>
+                        </fo:block>
                 </xsl:if>
 
                 <!-- Related Materials -->
                 <xsl:if test="ead:relatedmaterial or ead:separatedmaterial">
                     <fo:block text-align-last="justify">
-                        <fo:basic-link internal-destination="relMat">Related
-                            Materials</fo:basic-link>
+                        <fo:basic-link internal-destination="relMat">Related Materials</fo:basic-link>
                         <xsl:text>&#160;&#160;</xsl:text>
                         <fo:leader leader-pattern="dots"/>
                         <xsl:text>&#160;&#160;</xsl:text>
@@ -558,9 +490,7 @@
 
                 <xsl:if test="ead:controlaccess">
                     <fo:block text-align-last="justify">
-                        <fo:basic-link internal-destination="{local:buildID(ead:controlaccess[1])}">
-                            <xsl:value-of select="local:tagName(ead:controlaccess[1])"/>
-                        </fo:basic-link>
+                        <fo:basic-link internal-destination="{local:buildID(ead:controlaccess[1])}"><xsl:value-of select="local:tagName(ead:controlaccess[1])"/></fo:basic-link>
                         <xsl:text>&#160;&#160;</xsl:text>
                         <fo:leader leader-pattern="dots"/>
                         <xsl:text>&#160;&#160;</xsl:text>
@@ -569,9 +499,7 @@
                 </xsl:if>
                 <xsl:if test="ead:otherfindaid">
                     <fo:block text-align-last="justify">
-                        <fo:basic-link internal-destination="{local:buildID(ead:otherfindaid[1])}">
-                            <xsl:value-of select="local:tagName(ead:otherfindaid[1])"/>
-                        </fo:basic-link>
+                        <fo:basic-link internal-destination="{local:buildID(ead:otherfindaid[1])}"><xsl:value-of select="local:tagName(ead:otherfindaid[1])"/></fo:basic-link>
                         <xsl:text>&#160;&#160;</xsl:text>
                         <fo:leader leader-pattern="dots"/>
                         <xsl:text>&#160;&#160;</xsl:text>
@@ -580,9 +508,7 @@
                 </xsl:if>
                 <xsl:if test="ead:phystech">
                     <fo:block text-align-last="justify">
-                        <fo:basic-link internal-destination="{local:buildID(ead:phystech[1])}">
-                            <xsl:value-of select="local:tagName(ead:phystech[1])"/>
-                        </fo:basic-link>
+                        <fo:basic-link internal-destination="{local:buildID(ead:phystech[1])}"><xsl:value-of select="local:tagName(ead:phystech[1])"/></fo:basic-link>
                         <xsl:text>&#160;&#160;</xsl:text>
                         <fo:leader leader-pattern="dots"/>
                         <xsl:text>&#160;&#160;</xsl:text>
@@ -591,9 +517,7 @@
                 </xsl:if>
                 <xsl:if test="ead:odd">
                     <fo:block text-align-last="justify">
-                        <fo:basic-link internal-destination="{local:buildID(ead:odd[1])}">
-                            <xsl:value-of select="local:tagName(ead:odd[1])"/>
-                        </fo:basic-link>
+                        <fo:basic-link internal-destination="{local:buildID(ead:odd[1])}"><xsl:value-of select="local:tagName(ead:odd[1])"/></fo:basic-link>
                         <xsl:text>&#160;&#160;</xsl:text>
                         <fo:leader leader-pattern="dots"/>
                         <xsl:text>&#160;&#160;</xsl:text>
@@ -602,9 +526,7 @@
                 </xsl:if>
                 <xsl:if test="ead:bibliography">
                     <fo:block text-align-last="justify">
-                        <fo:basic-link internal-destination="{local:buildID(ead:bibliography[1])}">
-                            <xsl:value-of select="local:tagName(ead:bibliography[1])"/>
-                        </fo:basic-link>
+                        <fo:basic-link internal-destination="{local:buildID(ead:bibliography[1])}"><xsl:value-of select="local:tagName(ead:bibliography[1])"/></fo:basic-link>
                         <xsl:text>&#160;&#160;</xsl:text>
                         <fo:leader leader-pattern="dots"/>
                         <xsl:text>&#160;&#160;</xsl:text>
@@ -613,9 +535,7 @@
                 </xsl:if>
                 <xsl:if test="ead:index">
                     <fo:block text-align-last="justify">
-                        <fo:basic-link internal-destination="{local:buildID(ead:index[1])}">
-                            <xsl:value-of select="local:tagName(ead:index[1])"/>
-                        </fo:basic-link>
+                        <fo:basic-link internal-destination="{local:buildID(ead:index[1])}"><xsl:value-of select="local:tagName(ead:index[1])"/></fo:basic-link>
                         <xsl:text>&#160;&#160;</xsl:text>
                         <fo:leader leader-pattern="dots"/>
                         <xsl:text>&#160;&#160;</xsl:text>
@@ -627,9 +547,7 @@
                 <xsl:for-each select="ead:dsc">
                     <xsl:if test="child::*">
                         <fo:block text-align-last="justify">
-                            <fo:basic-link internal-destination="{local:buildID(.)}">
-                                <xsl:value-of select="local:tagName(.)"/>
-                            </fo:basic-link>
+                            <fo:basic-link internal-destination="{local:buildID(.)}"><xsl:value-of select="local:tagName(.)"/></fo:basic-link>
                             <xsl:text>&#160;&#160;</xsl:text>
                             <fo:leader leader-pattern="dots"/>
                             <xsl:text>&#160;&#160;</xsl:text>
@@ -637,8 +555,7 @@
                         </fo:block>
                     </xsl:if>
                     <!--Creates a submenu for collections, record groups and series and fonds-->
-                    <xsl:for-each
-                        select="child::*[@level = 'collection'] | child::*[@level = 'recordgrp'] | child::*[@level = 'series'] | child::*[@level = 'fonds']">
+                    <xsl:for-each select="child::*[@level = 'collection']  | child::*[@level = 'recordgrp']  | child::*[@level = 'series'] | child::*[@level = 'fonds']">
                         <fo:block text-align-last="justify" margin-left="8pt">
                             <fo:basic-link internal-destination="{local:buildID(.)}">
                                 <xsl:choose>
@@ -656,8 +573,7 @@
                             <fo:page-number-citation ref-id="{local:buildID(.)}"/>
                         </fo:block>
                         <!-- Creates a submenu for subfonds, subgrp or subseries -->
-                        <xsl:for-each
-                            select="child::*[@level = 'subfonds'] | child::*[@level = 'subgrp'] | child::*[@level = 'subseries']">
+                        <xsl:for-each select="child::*[@level = 'subfonds'] | child::*[@level = 'subgrp']  | child::*[@level = 'subseries']">
                             <fo:block text-align-last="justify" margin-left="16pt">
                                 <fo:basic-link internal-destination="{local:buildID(.)}">
                                     <xsl:choose>
@@ -678,7 +594,7 @@
                     </xsl:for-each>
                 </xsl:for-each>
             </fo:block>
-        </fo:block>
+            </fo:block>
     </xsl:template>
 
     <!--
@@ -686,55 +602,50 @@
         if order is changed it must also be changed in the table of contents.
     -->
     <xsl:template match="ead:archdesc">
-        <xsl:apply-templates select="ead:did"/>
-        <xsl:apply-templates select="ead:bioghist"/>
-        <xsl:apply-templates select="ead:scopecontent"/>
-        <xsl:apply-templates select="ead:arrangement"/>
-        <xsl:apply-templates select="ead:fileplan"/>
+            <xsl:apply-templates select="ead:did"/>
+            <xsl:apply-templates select="ead:bioghist"/>
+            <xsl:apply-templates select="ead:scopecontent"/>
+            <xsl:apply-templates select="ead:arrangement"/>
+            <xsl:apply-templates select="ead:fileplan"/>
 
-        <!-- Administrative Information  -->
-        <xsl:if
-            test="
-                ead:accessrestrict or ead:userestrict or
+            <!-- Administrative Information  -->
+            <xsl:if test="ead:accessrestrict or ead:userestrict or
                 ead:custodhist or ead:accruals or ead:altformavail or ead:acqinfo or
                 ead:processinfo or ead:appraisal or ead:originalsloc or
                 /ead:ead/ead:eadheader/ead:filedesc/ead:publicationstmt or /ead:ead/ead:eadheader/ead:revisiondesc">
-            <fo:block xsl:use-attribute-sets="section">
-                <fo:block xsl:use-attribute-sets="h2" id="adminInfo">Administrative
-                    Information</fo:block>
-                <xsl:apply-templates
-                    select="
-                        ead:accessrestrict | ead:userestrict |
+                <fo:block xsl:use-attribute-sets="section">
+                    <fo:block xsl:use-attribute-sets="h2" id="adminInfo">Administrative Information</fo:block>
+                    <xsl:apply-templates select="ead:accessrestrict | ead:userestrict |
                         ead:custodhist | ead:accruals | ead:altformavail | ead:acqinfo |
                         ead:processinfo | ead:appraisal | ead:originalsloc |
                         /ead:ead/ead:eadheader/ead:filedesc/ead:publicationstmt | /ead:ead/ead:eadheader/ead:revisiondesc"/>
-                <xsl:call-template name="toc"/>
-            </fo:block>
-        </xsl:if>
+                    <xsl:call-template name="toc"/>
+                </fo:block>
+            </xsl:if>
 
-        <!-- Related Materials -->
-        <xsl:if test="ead:relatedmaterial or ead:separatedmaterial">
-            <fo:block xsl:use-attribute-sets="section">
-                <fo:block xsl:use-attribute-sets="h2" id="relMat">Related Materials</fo:block>
-                <xsl:apply-templates select="ead:relatedmaterial | ead:separatedmaterial"/>
-                <xsl:call-template name="toc"/>
-            </fo:block>
-        </xsl:if>
+            <!-- Related Materials -->
+            <xsl:if test="ead:relatedmaterial or ead:separatedmaterial">
+                <fo:block xsl:use-attribute-sets="section">
+                    <fo:block xsl:use-attribute-sets="h2" id="relMat">Related Materials</fo:block>
+                    <xsl:apply-templates select="ead:relatedmaterial | ead:separatedmaterial"/>
+                    <xsl:call-template name="toc"/>
+                </fo:block>
+            </xsl:if>
 
-        <xsl:apply-templates select="ead:controlaccess"/>
-        <xsl:apply-templates select="ead:otherfindaid"/>
-        <xsl:apply-templates select="ead:phystech"/>
-        <xsl:apply-templates select="ead:odd"/>
-        <xsl:apply-templates select="ead:bibliography"/>
-        <xsl:apply-templates select="ead:index"/>
-        <xsl:apply-templates select="ead:dsc"/>
+            <xsl:apply-templates select="ead:controlaccess"/>
+            <xsl:apply-templates select="ead:otherfindaid"/>
+            <xsl:apply-templates select="ead:phystech"/>
+            <xsl:apply-templates select="ead:odd"/>
+            <xsl:apply-templates select="ead:bibliography"/>
+            <xsl:apply-templates select="ead:index"/>
+            <xsl:apply-templates select="ead:dsc"/>
     </xsl:template>
 
     <!-- Formats archdesc did -->
     <xsl:template match="ead:archdesc/ead:did">
         <fo:block xsl:use-attribute-sets="section">
-            <fo:block xsl:use-attribute-sets="h2ID">Summary Information</fo:block>
-            <!--
+        <fo:block xsl:use-attribute-sets="h2ID">Summary Information</fo:block>
+                <!--
                     Determines the order in wich elements from the archdesc did appear,
                     to change the order of appearance change the order of the following
                     apply-template statements.
@@ -744,20 +655,20 @@
                 <fo:table-column column-width="2in"/>
                 <fo:table-column column-width="5in"/>
                 <fo:table-body>
-                    <xsl:apply-templates select="ead:repository" mode="overview"/>
-                    <xsl:apply-templates select="ead:origination" mode="overview"/>
-                    <xsl:apply-templates select="ead:unittitle" mode="overview"/>
-                    <xsl:apply-templates select="ead:unitid" mode="overview"/>
-                    <xsl:apply-templates select="ead:unitdate" mode="overview"/>
-                    <xsl:apply-templates select="ead:physdesc" mode="overview"/>
-                    <xsl:apply-templates select="ead:physloc" mode="overview"/>
-                    <xsl:apply-templates select="ead:dao" mode="overview"/>
-                    <xsl:apply-templates select="ead:daogrp" mode="overview"/>
-                    <xsl:apply-templates select="ead:langmaterial" mode="overview"/>
-                    <xsl:apply-templates select="ead:materialspec" mode="overview"/>
-                    <xsl:apply-templates select="ead:container" mode="overview"/>
-                    <xsl:apply-templates select="ead:abstract" mode="overview"/>
-                    <xsl:apply-templates select="ead:note" mode="overview"/>
+                        <xsl:apply-templates select="ead:repository" mode="overview"/>
+                        <xsl:apply-templates select="ead:origination" mode="overview"/>
+                        <xsl:apply-templates select="ead:unittitle" mode="overview"/>
+                        <xsl:apply-templates select="ead:unitid" mode="overview"/>
+                        <xsl:apply-templates select="ead:unitdate" mode="overview"/>
+                        <xsl:apply-templates select="ead:physdesc" mode="overview"/>
+                        <xsl:apply-templates select="ead:physloc" mode="overview"/>
+                        <xsl:apply-templates select="ead:dao" mode="overview"/>
+                        <xsl:apply-templates select="ead:daogrp" mode="overview"/>
+                        <xsl:apply-templates select="ead:langmaterial" mode="overview"/>
+                        <xsl:apply-templates select="ead:materialspec" mode="overview"/>
+                        <xsl:apply-templates select="ead:container" mode="overview"/>
+                        <xsl:apply-templates select="ead:abstract" mode="overview"/>
+                        <xsl:apply-templates select="ead:note" mode="overview"/>
                 </fo:table-body>
             </fo:table>
             <!-- Adds prefered citation to summary information -->
@@ -770,9 +681,7 @@
     <!-- Formats prefercite in the summary -->
     <xsl:template match="ead:prefercite" mode="overview">
         <fo:block xsl:use-attribute-sets="section" border="1pt solid #333">
-            <fo:block xsl:use-attribute-sets="h3ID">
-                <xsl:value-of select="local:tagName(.)"/>
-            </fo:block>
+            <fo:block xsl:use-attribute-sets="h3ID"><xsl:value-of select="local:tagName(.)"/></fo:block>
             <fo:block xsl:use-attribute-sets="smp">
                 <xsl:apply-templates/>
             </fo:block>
@@ -780,42 +689,36 @@
     </xsl:template>
 
     <!-- Formats children of arcdesc/did -->
-    <xsl:template
-        match="
-            ead:repository | ead:origination | ead:unittitle | ead:unitdate | ead:unitid
-            | ead:physdesc | ead:physloc | ead:dao | ead:daogrp | ead:langmaterial | ead:materialspec | ead:container
-            | ead:abstract | ead:note"
-        mode="overview">
+    <xsl:template match="ead:repository | ead:origination | ead:unittitle | ead:unitdate | ead:unitid
+        | ead:physdesc | ead:physloc | ead:dao | ead:daogrp | ead:langmaterial | ead:materialspec | ead:container
+        | ead:abstract | ead:note" mode="overview">
         <fo:table-row>
-            <fo:table-cell padding-bottom="8pt" padding-right="16pt" text-align="right"
-                font-weight="bold">
+            <fo:table-cell padding-bottom="8pt" padding-right="16pt" text-align="right" font-weight="bold">
                 <fo:block>
-                    <xsl:choose>
-                        <!-- Test for label attribute used by origination element -->
-                        <xsl:when test="@label">
-                            <xsl:value-of
-                                select="concat(upper-case(substring(@label, 1, 1)), substring(@label, 2))"/>
-                            <xsl:if test="@type"> [<xsl:value-of select="@type"/>]</xsl:if>
-                            <xsl:if test="self::ead:origination">
-                                <xsl:choose>
-                                    <xsl:when
-                                        test="ead:persname[@role != ''] and contains(ead:persname/@role, ' (')"
-                                        > - <xsl:value-of
-                                            select="substring-before(ead:persname/@role, ' (')"/>
-                                    </xsl:when>
-                                    <xsl:when test="ead:persname[@role != '']"> - <xsl:value-of
-                                            select="ead:persname/@role"/>
-                                    </xsl:when>
-                                    <xsl:otherwise/>
-                                </xsl:choose>
-                            </xsl:if>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:value-of select="local:tagName(.)"/>
-                            <!-- Test for type attribute used by unitdate -->
-                            <xsl:if test="@type"> [<xsl:value-of select="@type"/>]</xsl:if>
-                        </xsl:otherwise>
-                    </xsl:choose>: </fo:block>
+                <xsl:choose>
+                    <!-- Test for label attribute used by origination element -->
+                    <xsl:when test="@label">
+                        <xsl:value-of select="concat(upper-case(substring(@label,1,1)),substring(@label,2))"></xsl:value-of>
+                        <xsl:if test="@type"> [<xsl:value-of select="@type"/>]</xsl:if>
+                        <xsl:if test="self::ead:origination">
+                            <xsl:choose>
+                                <xsl:when test="ead:persname[@role != ''] and contains(ead:persname/@role,' (')">
+                                    - <xsl:value-of select="substring-before(ead:persname/@role,' (')"/>
+                                </xsl:when>
+                                <xsl:when test="ead:persname[@role != '']">
+                                    - <xsl:value-of select="ead:persname/@role"/>
+                                </xsl:when>
+                                <xsl:otherwise/>
+                            </xsl:choose>
+                        </xsl:if>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="local:tagName(.)"/>
+                        <!-- Test for type attribute used by unitdate -->
+                        <xsl:if test="@type"> [<xsl:value-of select="@type"/>]</xsl:if>
+                    </xsl:otherwise>
+                </xsl:choose>:
+                </fo:block>
             </fo:table-cell>
             <fo:table-cell padding-bottom="2pt">
                 <fo:block>
@@ -828,39 +731,29 @@
     <xsl:template match="ead:extent"><xsl:apply-templates/>&#160;</xsl:template>
 
     <!-- Formats children of arcdesc not in administrative or related materials sections-->
-    <xsl:template
-        match="
-            ead:bibliography | ead:odd | ead:phystech | ead:otherfindaid |
-            ead:bioghist | ead:scopecontent | ead:arrangement | ead:fileplan">
+    <xsl:template match="ead:bibliography | ead:odd | ead:phystech | ead:otherfindaid |
+        ead:bioghist | ead:scopecontent | ead:arrangement | ead:fileplan">
         <fo:block xsl:use-attribute-sets="section">
-            <fo:block xsl:use-attribute-sets="h2ID">
-                <xsl:value-of select="local:tagName(.)"/>
-            </fo:block>
-            <xsl:apply-templates/>
+            <fo:block xsl:use-attribute-sets="h2ID"><xsl:value-of select="local:tagName(.)"/></fo:block>
+                <xsl:apply-templates/>
             <xsl:call-template name="toc"/>
         </fo:block>
     </xsl:template>
 
     <!-- Formats children of arcdesc in administrative and related materials sections -->
-    <xsl:template
-        match="
-            ead:relatedmaterial | ead:separatedmaterial | ead:accessrestrict | ead:userestrict |
-            ead:custodhist | ead:accruals | ead:altformavail | ead:acqinfo |
-            ead:processinfo | ead:appraisal | ead:originalsloc">
+    <xsl:template match="ead:relatedmaterial | ead:separatedmaterial | ead:accessrestrict | ead:userestrict |
+        ead:custodhist | ead:accruals | ead:altformavail | ead:acqinfo |
+        ead:processinfo | ead:appraisal | ead:originalsloc">
         <fo:block xsl:use-attribute-sets="section">
-            <fo:block xsl:use-attribute-sets="h3ID">
-                <xsl:value-of select="local:tagName(.)"/>
-            </fo:block>
-            <xsl:apply-templates/>
+            <fo:block xsl:use-attribute-sets="h3ID"><xsl:value-of select="local:tagName(.)"/></fo:block>
+                <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <!-- Publication statement included in administrative information section -->
     <xsl:template match="ead:publicationstmt">
         <fo:block xsl:use-attribute-sets="section">
-            <fo:block xsl:use-attribute-sets="h3">
-                <xsl:value-of select="local:tagName(.)"/>
-            </fo:block>
+            <fo:block xsl:use-attribute-sets="h3"><xsl:value-of select="local:tagName(.)"/></fo:block>
             <fo:block xsl:use-attribute-sets="smp">
                 <xsl:apply-templates select="ead:publisher"/>
                 <xsl:if test="ead:date">&#160;<xsl:apply-templates select="ead:date"/></xsl:if>
@@ -877,10 +770,9 @@
     </xsl:template>
     <xsl:template match="ead:addressline">
         <xsl:choose>
-            <xsl:when test="contains(., '@')">
+            <xsl:when test="contains(.,'@')">
                 <fo:block>
-                    <fo:basic-link external-destination="url('mailto:{.}')"
-                        xsl:use-attribute-sets="ref">
+                    <fo:basic-link external-destination="url('mailto:{.}')" xsl:use-attribute-sets="ref">
                         <xsl:value-of select="."/>
                     </fo:basic-link>
                 </fo:block>
@@ -896,23 +788,16 @@
     <!-- Templates for revision description  -->
     <xsl:template match="ead:revisiondesc">
         <fo:block xsl:use-attribute-sets="section">
-            <fo:block xsl:use-attribute-sets="h3ID">
-                <xsl:value-of select="local:tagName(.)"/>
-            </fo:block>
-            <xsl:if test="ead:change/ead:item">
-                <xsl:value-of select="ead:change/ead:item"/>
-            </xsl:if>
-            <xsl:if test="ead:change/ead:date">&#160;<xsl:value-of select="ead:change/ead:date"
-                /></xsl:if>
+            <fo:block xsl:use-attribute-sets="h3ID"><xsl:value-of select="local:tagName(.)"/></fo:block>
+            <xsl:if test="ead:change/ead:item"><xsl:value-of select="ead:change/ead:item"/></xsl:if>
+            <xsl:if test="ead:change/ead:date">&#160;<xsl:value-of select="ead:change/ead:date"/></xsl:if>
         </fo:block>
     </xsl:template>
 
     <!-- Formats controlled access terms -->
     <xsl:template match="ead:controlaccess">
         <fo:block xsl:use-attribute-sets="section">
-            <fo:block xsl:use-attribute-sets="h2ID">
-                <xsl:value-of select="local:tagName(.)"/>
-            </fo:block>
+            <fo:block xsl:use-attribute-sets="h2ID"><xsl:value-of select="local:tagName(.)"/></fo:block>
             <fo:list-block xsl:use-attribute-sets="smp">
                 <xsl:apply-templates/>
             </fo:list-block>
@@ -934,18 +819,16 @@
     <!-- Formats index and child elements, groups indexentry elements by type (i.e. corpname, subject...) -->
     <xsl:template match="ead:index">
         <fo:block xsl:use-attribute-sets="section">
-            <fo:block xsl:use-attribute-sets="h2ID">
-                <xsl:value-of select="local:tagName(.)"/>
-            </fo:block>
+            <fo:block xsl:use-attribute-sets="h2ID"><xsl:value-of select="local:tagName(.)"/></fo:block>
             <xsl:apply-templates select="child::*[not(self::ead:indexentry)]"/>
             <fo:list-block xsl:use-attribute-sets="smp">
-                <xsl:apply-templates select="ead:indexentry"/>
+            <xsl:apply-templates select="ead:indexentry"/>
             </fo:list-block>
         </fo:block>
     </xsl:template>
     <xsl:template match="ead:indexentry">
         <fo:list-item>
-            <fo:list-item-label end-indent="label-end()">
+            <fo:list-item-label  end-indent="label-end()">
                 <fo:block>&#x2022;</fo:block>
             </fo:list-item-label>
             <fo:list-item-body start-indent="body-start()">
@@ -961,9 +844,7 @@
         <xsl:apply-templates/>
     </xsl:template>
     <xsl:template match="ead:table/ead:thead">
-        <fo:block xsl:use-attribute-sets="h4ID">
-            <xsl:apply-templates/>
-        </fo:block>
+        <fo:block xsl:use-attribute-sets="h4ID"><xsl:apply-templates/></fo:block>
     </xsl:template>
     <xsl:template match="ead:tgroup">
         <fo:table xsl:use-attribute-sets="tableBorder">
@@ -985,14 +866,10 @@
         </fo:table-body>
     </xsl:template>
     <xsl:template match="ead:row" mode="thead">
-        <fo:table-row xsl:use-attribute-sets="th">
-            <xsl:apply-templates/>
-        </fo:table-row>
+        <fo:table-row xsl:use-attribute-sets="th"><xsl:apply-templates/></fo:table-row>
     </xsl:template>
     <xsl:template match="ead:row">
-        <fo:table-row>
-            <xsl:apply-templates/>
-        </fo:table-row>
+        <fo:table-row><xsl:apply-templates/></fo:table-row>
     </xsl:template>
     <xsl:template match="ead:entry">
         <fo:table-cell xsl:use-attribute-sets="tdBorder">
@@ -1020,10 +897,7 @@
         <fo:block>
             <xsl:choose>
                 <xsl:when test="@*:href">
-                    <fo:basic-link external-destination="url('{@*:href}')"
-                        xsl:use-attribute-sets="ref">
-                        <xsl:apply-templates/>
-                    </fo:basic-link>
+                    <fo:basic-link external-destination="url('{@*:href}')" xsl:use-attribute-sets="ref"><xsl:apply-templates/></fo:basic-link>
                 </xsl:when>
                 <xsl:otherwise>
                     <xsl:apply-templates/>
@@ -1059,7 +933,7 @@
         <xsl:apply-templates select="ead:head"/>
         <fo:list-block xsl:use-attribute-sets="smp">
             <xsl:choose>
-                <xsl:when test="@type = 'deflist'">
+                <xsl:when test="@type='deflist'">
                     <xsl:apply-templates select="ead:defitem"/>
                 </xsl:when>
                 <xsl:otherwise>
@@ -1070,25 +944,25 @@
     </xsl:template>
     <xsl:template match="ead:item">
         <fo:list-item>
-            <fo:list-item-label end-indent="label-end()">
+            <fo:list-item-label  end-indent="label-end()">
                 <fo:block>
                     <xsl:choose>
-                        <xsl:when test="../@type = 'ordered' and ../@numeration = 'arabic'">
+                        <xsl:when test="../@type='ordered' and ../@numeration = 'arabic'">
                             <xsl:number format="1"/>
                         </xsl:when>
-                        <xsl:when test="../@type = 'ordered' and ../@numeration = 'upperalpha'">
+                        <xsl:when test="../@type='ordered' and ../@numeration = 'upperalpha'">
                             <xsl:number format="A"/>
                         </xsl:when>
-                        <xsl:when test="../@type = 'ordered' and ../@numeration = 'loweralpha'">
+                        <xsl:when test="../@type='ordered' and ../@numeration = 'loweralpha'">
                             <xsl:number format="a"/>
                         </xsl:when>
-                        <xsl:when test="../@type = 'ordered' and ../@numeration = 'upperroman'">
+                        <xsl:when test="../@type='ordered' and ../@numeration = 'upperroman'">
                             <xsl:number format="I"/>
                         </xsl:when>
-                        <xsl:when test="../@type = 'ordered' and ../@numeration = 'upperalpha'">
+                        <xsl:when test="../@type='ordered' and ../@numeration = 'upperalpha'">
                             <xsl:number format="i"/>
                         </xsl:when>
-                        <xsl:when test="../@type = 'ordered' and not(../@numeration)">
+                        <xsl:when test="../@type='ordered' and not(../@numeration)">
                             <xsl:number format="1"/>
                         </xsl:when>
                         <xsl:otherwise>&#x2022;</xsl:otherwise>
@@ -1104,7 +978,7 @@
     </xsl:template>
     <xsl:template match="ead:defitem">
         <fo:list-item>
-            <fo:list-item-label end-indent="label-end()">
+            <fo:list-item-label  end-indent="label-end()">
                 <fo:block/>
             </fo:list-item-label>
             <fo:list-item-body start-indent="body-start()">
@@ -1174,12 +1048,12 @@
                     <xsl:otherwise>#eee</xsl:otherwise>
                 </xsl:choose>
             </xsl:attribute>
-            <fo:table-cell xsl:use-attribute-sets="tdBorder">
+            <fo:table-cell  xsl:use-attribute-sets="tdBorder">
                 <fo:block xsl:use-attribute-sets="smp">
                     <xsl:apply-templates select="ead:date"/>
                 </fo:block>
             </fo:table-cell>
-            <fo:table-cell xsl:use-attribute-sets="tdBorder">
+            <fo:table-cell  xsl:use-attribute-sets="tdBorder">
                 <fo:block xsl:use-attribute-sets="smp">
                     <xsl:apply-templates select="descendant::ead:event"/>
                 </fo:block>
@@ -1189,9 +1063,7 @@
     <xsl:template match="ead:event">
         <xsl:choose>
             <xsl:when test="following-sibling::*">
-                <fo:block>
-                    <xsl:apply-templates/>
-                </fo:block>
+                <fo:block><xsl:apply-templates/></fo:block>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:apply-templates/>
@@ -1213,16 +1085,8 @@
             </xsl:when>
             <xsl:otherwise>
                 <xsl:choose>
-                    <xsl:when test="@label">
-                        <fo:block xsl:use-attribute-sets="h4ID">
-                            <xsl:value-of select="@label"/>
-                        </fo:block>
-                        <xsl:apply-templates/>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <fo:block xsl:use-attribute-sets="h4ID">Note</fo:block>
-                        <xsl:apply-templates/>
-                    </xsl:otherwise>
+                    <xsl:when test="@label"><fo:block xsl:use-attribute-sets="h4ID"><xsl:value-of select="@label"/></fo:block><xsl:apply-templates/></xsl:when>
+                    <xsl:otherwise><fo:block xsl:use-attribute-sets="h4ID">Note</fo:block><xsl:apply-templates/></xsl:otherwise>
                 </xsl:choose>
             </xsl:otherwise>
         </xsl:choose>
@@ -1231,8 +1095,7 @@
     <!-- Formats legalstatus -->
     <xsl:template match="ead:legalstatus">
         <fo:block xsl:use-attribute-sets="smp">
-            <fo:inline font-weight="bold"><xsl:value-of select="local:tagName(.)"
-                />:&#160;</fo:inline>
+            <fo:inline font-weight="bold"><xsl:value-of select="local:tagName(.)"/>:&#160;</fo:inline>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
@@ -1242,14 +1105,12 @@
     <xsl:template match="ead:head[parent::*/parent::ead:archdesc]"/>
     <!-- All other headings -->
     <xsl:template match="ead:head">
-        <fo:block xsl:use-attribute-sets="h4" id="{local:buildID(parent::*)}">
-            <xsl:apply-templates/>
-        </fo:block>
+        <fo:block xsl:use-attribute-sets="h4" id="{local:buildID(parent::*)}"><xsl:apply-templates/></fo:block>
     </xsl:template>
 
-    <!-- Linking elmenets -->
+   <!-- Linking elmenets -->
     <xsl:template match="ead:ref">
-        <fo:basic-link internal-destination="{@target}" xsl:use-attribute-sets="ref">
+        <fo:basic-link internal-destination="{@*:target}" xsl:use-attribute-sets="ref">
             <xsl:choose>
                 <xsl:when test="text()">
                     <xsl:value-of select="."/>
@@ -1258,13 +1119,13 @@
                     <xsl:value-of select="@*:title"/>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:value-of select="@target"/>
+                    <xsl:value-of select="@*:target"/>
                 </xsl:otherwise>
             </xsl:choose>
         </fo:basic-link>
     </xsl:template>
     <xsl:template match="ead:ptr">
-        <fo:basic-link external-destination="url('{@target}')" xsl:use-attribute-sets="ref">
+        <fo:basic-link external-destination="url('{@*:target}')" xsl:use-attribute-sets="ref">
             <xsl:choose>
                 <xsl:when test="child::*">
                     <xsl:value-of select="."/>
@@ -1273,7 +1134,7 @@
                     <xsl:value-of select="@*:title"/>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:value-of select="@target"/>
+                    <xsl:value-of select="@*:target"/>
                 </xsl:otherwise>
             </xsl:choose>
         </fo:basic-link>
@@ -1305,24 +1166,16 @@
     <xsl:template match="ead:extptr[@*:entityref]">
         <fo:basic-link external-destination="url('{@*:entityref}')" xsl:use-attribute-sets="ref">
             <xsl:choose>
-                <xsl:when test="@*:title">
-                    <xsl:value-of select="@*:title"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:value-of select="@*:entityref"/>
-                </xsl:otherwise>
+                <xsl:when test="@*:title"><xsl:value-of select="@*:title"/></xsl:when>
+                <xsl:otherwise><xsl:value-of select="@*:entityref"/></xsl:otherwise>
             </xsl:choose>
         </fo:basic-link>
     </xsl:template>
     <xsl:template match="ead:extptr[@*:href]">
         <fo:basic-link external-destination="url('{@*:href}')" xsl:use-attribute-sets="ref">
             <xsl:choose>
-                <xsl:when test="@*:title">
-                    <xsl:value-of select="@*:title"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:value-of select="@*:href"/>
-                </xsl:otherwise>
+                <xsl:when test="@*:title"><xsl:value-of select="@*:title"/></xsl:when>
+                <xsl:otherwise><xsl:value-of select="@*:href"/></xsl:otherwise>
             </xsl:choose>
         </fo:basic-link>
     </xsl:template>
@@ -1363,7 +1216,7 @@
     </xsl:template>
 
     <!--Render elements -->
-    <xsl:template match="*[@render = 'bold'] | *[@altrender = 'bold']">
+    <xsl:template match="*[@render = 'bold'] | *[@altrender = 'bold'] ">
         <fo:inline font-weight="bold">
             <xsl:if test="preceding-sibling::*"> &#160;</xsl:if>
             <xsl:apply-templates/>
@@ -1429,74 +1282,59 @@
 
     <!-- Formatting elements -->
     <xsl:template match="ead:p">
-        <fo:block xsl:use-attribute-sets="smp">
-            <xsl:apply-templates/>
-        </fo:block>
+        <fo:block xsl:use-attribute-sets="smp"><xsl:apply-templates/></fo:block>
     </xsl:template>
-    <xsl:template match="ead:lb">
-        <fo:block/>
-    </xsl:template>
+    <xsl:template match="ead:lb"><fo:block/></xsl:template>
     <xsl:template match="ead:blockquote">
-        <fo:block margin="4pt 18pt">
-            <xsl:apply-templates/>
-        </fo:block>
+        <fo:block margin="4pt 18pt"><xsl:apply-templates/></fo:block>
     </xsl:template>
-    <xsl:template match="ead:emph[not(@render)]">
-        <fo:inline font-style="italic">
-            <xsl:apply-templates/>
-        </fo:inline>
-    </xsl:template>
-<!-- FOX: render the text in the title element as italic -->
+    <xsl:template match="ead:emph[not(@render)]"><fo:inline font-style="italic"><xsl:apply-templates/></fo:inline></xsl:template>
+
+    <!-- FOX: render the text in the title element as italic -->
     <xsl:template match="ead:title">
         <fo:inline font-style="italic"><xsl:apply-templates/></fo:inline>
     </xsl:template>
+    
     <!-- Collection Inventory (dsc) templates -->
     <xsl:template match="ead:archdesc/ead:dsc">
         <xsl:if test="count(child::*) >= 1">
-            <fo:block xsl:use-attribute-sets="section">
-                <fo:block xsl:use-attribute-sets="h2ID">
-                    <xsl:value-of select="local:tagName(.)"/>
-                </fo:block>
-                <fo:table table-layout="fixed" space-after="12pt" width="100%" font-size="10pt">
-                    <fo:table-column column-number="1" column-width="4in"/>
-                    <fo:table-column column-number="2" column-width="1in"/>
-                    <fo:table-column column-number="3" column-width="1in"/>
-                    <fo:table-column column-number="4" column-width="1in"/>
-                    <fo:table-body>
-                        <xsl:if
-                            test="child::*[@level][1][@level = 'item' or @level = 'file' or @level = 'otherlevel']">
-                            <xsl:call-template name="tableHeaders"/>
-                        </xsl:if>
-                        <xsl:apply-templates select="*[not(self::ead:head)]"/>
-                    </fo:table-body>
-                </fo:table>
-            </fo:block>
-        </xsl:if>
+		<fo:block xsl:use-attribute-sets="section">
+		    <fo:block xsl:use-attribute-sets="h2ID"><xsl:value-of select="local:tagName(.)"/></fo:block>
+		    <fo:table table-layout="fixed" space-after="12pt" width="100%" font-size="10pt">
+			<fo:table-column column-number="1" column-width="4in"/>
+			<fo:table-column column-number="2" column-width="1in"/>
+			<fo:table-column column-number="3" column-width="1in"/>
+			<fo:table-column column-number="4" column-width="1in"/>
+			<fo:table-body>
+			    <xsl:if test="child::*[@level][1][@level='item' or @level='file' or @level='otherlevel']">
+				<xsl:call-template name="tableHeaders"/>
+			    </xsl:if>
+			    <xsl:apply-templates select="*[not(self::ead:head)]"/>
+			</fo:table-body>
+		    </fo:table>
+		</fo:block>
+	</xsl:if>
     </xsl:template>
 
     <!--
         Calls the clevel template passes the calculates the level of current component in xml tree and passes it to clevel template via the level parameter
         Adds a row to with a link to top if level series
     -->
-    <xsl:template
-        match="ead:c | ead:c01 | ead:c02 | ead:c03 | ead:c04 | ead:c05 | ead:c06 | ead:c07 | ead:c08 | ead:c09 | ead:c10 | ead:c11 | ead:c12">
-        <xsl:variable name="findClevel"
-            select="count(ancestor::*[not(ead:dsc or ead:archdesc or ead:ead)])"/>
+    <xsl:template match="ead:c | ead:c01 | ead:c02 | ead:c03 | ead:c04 | ead:c05 | ead:c06 | ead:c07 | ead:c08 | ead:c09 | ead:c10 | ead:c11 | ead:c12">
+        <xsl:variable name="findClevel" select="count(ancestor::*[not(ead:dsc or ead:archdesc or ead:ead)])"/>
         <xsl:call-template name="clevel">
-            <xsl:with-param name="level" select="$findClevel"/>
+            <xsl:with-param name="level" select="$findClevel"></xsl:with-param>
         </xsl:call-template>
-        <xsl:if test="@level = 'series'">
+        <xsl:if test="@level='series'">
             <fo:table-row>
-                <fo:table-cell number-columns-spanned="3">
-                    <xsl:call-template name="toc"/>
-                </fo:table-cell>
+                <fo:table-cell number-columns-spanned="3"><xsl:call-template name="toc"/></fo:table-cell>
             </fo:table-row>
         </xsl:if>
     </xsl:template>
     <!--This is a named template that processes all the components  -->
     <xsl:template name="clevel">
         <!-- Establishes which level is being processed in order to provided indented displays. -->
-        <xsl:param name="level"/>
+        <xsl:param name="level" />
         <xsl:variable name="clevelMargin">
             <xsl:choose>
                 <xsl:when test="$level = 1">4pt</xsl:when>
@@ -1513,204 +1351,151 @@
                 <xsl:when test="$level = 12">90pt</xsl:when>
             </xsl:choose>
         </xsl:variable>
-        <xsl:choose>
-            <!--Formats Series and Groups  -->
-            <xsl:when
-                test="
-                    @level = 'subcollection' or @level = 'subgrp' or @level = 'series'
-                    or @level = 'subseries' or @level = 'collection' or @level = 'fonds' or
-                    @level = 'recordgrp' or @level = 'subfonds' or @level = 'class' or (@level = 'otherlevel' and not(child::ead:did/ead:container))">
-                <fo:table-row background-color="#f0f0f0" border-bottom="1px dotted #ccc"
-                    border-top="3pt solid #ccc" keep-with-next.within-page="always">
-                    <fo:table-cell margin-left="{$clevelMargin}" padding-top="4pt">
-                        <xsl:if test="not(ead:did/ead:container)">
-                            <xsl:attribute name="number-columns-spanned">4</xsl:attribute>
-                        </xsl:if>
-                        <xsl:if test="ead:did/ead:container">
-                            <xsl:attribute name="number-rows-spanned">
-                                <xsl:choose>
-                                    <xsl:when test="ead:did/ead:container/@label">
-                                        <xsl:value-of
-                                            select="count(ead:did/ead:container[@label]) + 1"/>
-                                    </xsl:when>
-                                    <xsl:otherwise>2</xsl:otherwise>
-                                </xsl:choose>
-                            </xsl:attribute>
-                        </xsl:if>
-                        <xsl:apply-templates select="ead:did" mode="dscSeriesTitle"/>
-                        <xsl:apply-templates select="ead:did" mode="dscSeries"/>
-                        <xsl:apply-templates select="child::*[not(ead:did) and not(self::ead:did)]"
-                            mode="dsc"/>
-                    </fo:table-cell>
-                </fo:table-row>
-                <!-- Adds grouped instances if they exist -->
-                <xsl:if test="ead:did/ead:container">
-                    <xsl:choose>
-                        <xsl:when test="ead:did/ead:container/@label">
-                            <xsl:for-each-group select="ead:did/ead:container"
-                                group-starting-with=".[@label]">
-                                <fo:table-row background-color="#f0f0f0"
-                                    border-bottom="1px dotted #ccc" border-top="3pt solid #ccc"
-                                    keep-with-next.within-page="always">
-                                    <xsl:apply-templates select="current-group()"/>
+            <xsl:choose>
+                <!--Formats Series and Groups  -->
+                <xsl:when test="@level='subcollection' or @level='subgrp' or @level='series'
+                    or @level='subseries' or @level='collection'or @level='fonds' or
+                    @level='recordgrp' or @level='subfonds' or @level='class' or (@level='otherlevel' and not(child::ead:did/ead:container))">
+                    <fo:table-row background-color="#f0f0f0" border-bottom="1px dotted #ccc" border-top="3pt solid #ccc" keep-with-next.within-page="always">
+                        <fo:table-cell margin-left="{$clevelMargin}" padding-top="4pt">
+                            <xsl:if test="not(ead:did/ead:container)">
+                                    <xsl:attribute name="number-columns-spanned">4</xsl:attribute>
+                            </xsl:if>
+                            <xsl:if test="ead:did/ead:container">
+                                <xsl:attribute name="number-rows-spanned">
+                                    <xsl:choose>
+                                        <xsl:when test="ead:did/ead:container/@label"><xsl:value-of select="count(ead:did/ead:container[@label]) + 1"/></xsl:when>
+                                        <xsl:otherwise>2</xsl:otherwise>
+                                    </xsl:choose>
+                                </xsl:attribute>
+                            </xsl:if>
+                            <xsl:apply-templates select="ead:did" mode="dscSeriesTitle"/>
+                            <xsl:apply-templates select="ead:did" mode="dscSeries"/>
+                            <xsl:apply-templates select="child::*[not(ead:did) and not(self::ead:did)]" mode="dsc"/>
+                        </fo:table-cell>
+                    </fo:table-row>
+                    <!-- Adds grouped instances if they exist -->
+                    <xsl:if test="ead:did/ead:container">
+                        <xsl:choose>
+                            <xsl:when test="ead:did/ead:container/@label">
+                                <xsl:for-each-group select="ead:did/ead:container" group-starting-with=".[@label]">
+                                    <fo:table-row background-color="#f0f0f0" border-bottom="1px dotted #ccc" border-top="3pt solid #ccc" keep-with-next.within-page="always">
+                                        <xsl:apply-templates select="current-group()"/>
+                                        <xsl:choose>
+                                            <xsl:when test="count(current-group()) &lt; 2">
+                                                <fo:table-cell><fo:block/></fo:table-cell>
+                                                <fo:table-cell><fo:block/></fo:table-cell>
+                                            </xsl:when>
+                                            <xsl:when test="count(current-group()) &lt; 3">
+                                                <fo:table-cell><fo:block/></fo:table-cell>
+                                            </xsl:when>
+                                        </xsl:choose>
+                                    </fo:table-row>
+                                </xsl:for-each-group>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <fo:table-row>
+                                    <xsl:for-each select="ead:did/ead:container">
+                                        <xsl:apply-templates/>
+                                    </xsl:for-each>
                                     <xsl:choose>
                                         <xsl:when test="count(current-group()) &lt; 2">
-                                            <fo:table-cell>
-                                                <fo:block/>
-                                            </fo:table-cell>
-                                            <fo:table-cell>
-                                                <fo:block/>
-                                            </fo:table-cell>
+                                            <fo:table-cell><fo:block/></fo:table-cell>
+                                            <fo:table-cell><fo:block/></fo:table-cell>
                                         </xsl:when>
                                         <xsl:when test="count(current-group()) &lt; 3">
-                                            <fo:table-cell>
-                                                <fo:block/>
-                                            </fo:table-cell>
+                                            <fo:table-cell><fo:block/></fo:table-cell>
                                         </xsl:when>
                                     </xsl:choose>
                                 </fo:table-row>
-                            </xsl:for-each-group>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <fo:table-row>
-                                <xsl:for-each select="ead:did/ead:container">
-                                    <xsl:apply-templates/>
-                                </xsl:for-each>
-                                <xsl:choose>
-                                    <xsl:when test="count(current-group()) &lt; 2">
-                                        <fo:table-cell>
-                                            <fo:block/>
-                                        </fo:table-cell>
-                                        <fo:table-cell>
-                                            <fo:block/>
-                                        </fo:table-cell>
-                                    </xsl:when>
-                                    <xsl:when test="count(current-group()) &lt; 3">
-                                        <fo:table-cell>
-                                            <fo:block/>
-                                        </fo:table-cell>
-                                    </xsl:when>
-                                </xsl:choose>
-                            </fo:table-row>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                </xsl:if>
-                <!-- Adds column headings if series/subseries is followed by an item -->
-                <xsl:if
-                    test="child::*[@level][1][@level = 'item' or @level = 'file' or @level = 'otherlevel']">
-                    <xsl:call-template name="tableHeaders"/>
-                </xsl:if>
-            </xsl:when>
-            <!-- Groups instances by label attribute, the way they are grouped in ArchivesSpace -->
-            <xsl:when test="ead:did/ead:container[@label]">
-                <fo:table-row border-top="1px solid #ccc" keep-with-next.within-page="always">
-                    <fo:table-cell margin-left="{$clevelMargin}" padding-top="4pt"
-                        number-rows-spanned="{count(ead:did/ead:container[@label]) + 1}">
-                        <xsl:if test="not(ead:did/ead:container)">
-                            <xsl:attribute name="number-columns-spanned">4</xsl:attribute>
-                        </xsl:if>
-                        <xsl:apply-templates select="ead:did" mode="dsc"/>
-                        <xsl:apply-templates mode="dsc"
-                            select="
-                                *[not(self::ead:did) and
-                                not(self::ead:c) and not(self::ead:c02) and not(self::ead:c03) and
-                                not(self::ead:c04) and not(self::ead:c05) and not(self::ead:c06) and not(self::ead:c07)
-                                and not(self::ead:c08) and not(self::ead:c09) and not(self::ead:c10) and not(self::ead:c11) and not(self::ead:c12)]"
-                        />
-                    </fo:table-cell>
-                </fo:table-row>
-                <!-- Groups instances by label attribute, the way they are grouped in ArchivesSpace -->
-                <xsl:for-each-group select="ead:did/ead:container" group-starting-with=".[@label]">
-                    <fo:table-row keep-with-next.within-page="always">
-                        <xsl:apply-templates select="current-group()"/>
-                        <xsl:choose>
-                            <xsl:when test="count(current-group()) &lt; 2">
-                                <fo:table-cell>
-                                    <fo:block/>
-                                </fo:table-cell>
-                                <fo:table-cell>
-                                    <fo:block/>
-                                </fo:table-cell>
-                            </xsl:when>
-                            <xsl:when test="count(current-group()) &lt; 3">
-                                <fo:table-cell>
-                                    <fo:block/>
-                                </fo:table-cell>
-                            </xsl:when>
+                            </xsl:otherwise>
                         </xsl:choose>
-                    </fo:table-row>
-                </xsl:for-each-group>
-            </xsl:when>
-            <!-- For finding aids with no @label attribute, only accounts for three containers -->
-            <xsl:otherwise>
-                <fo:table-row border-top="1px solid #ccc">
-                    <fo:table-cell margin-left="{$clevelMargin}" padding-top="4pt"
-                        number-rows-spanned="{count(ead:did/ead:container[@label]) + 1}">
-                        <xsl:apply-templates select="ead:did" mode="dsc"/>
-                        <xsl:apply-templates mode="dsc"
-                            select="
-                                *[not(self::ead:did) and
+                    </xsl:if>
+                    <!-- Adds column headings if series/subseries is followed by an item -->
+                    <xsl:if test="child::*[@level][1][@level='item' or @level='file' or @level='otherlevel']">
+                        <xsl:call-template name="tableHeaders"/>
+                    </xsl:if>
+                </xsl:when>
+                <!-- Groups instances by label attribute, the way they are grouped in ArchivesSpace -->
+                <xsl:when test="ead:did/ead:container[@label]">
+                    <fo:table-row border-top="1px solid #ccc" keep-with-next.within-page="always">
+                        <fo:table-cell margin-left="{$clevelMargin}"  padding-top="4pt" number-rows-spanned="{count(ead:did/ead:container[@label]) + 1}">
+                            <xsl:if test="not(ead:did/ead:container)">
+                                <xsl:attribute name="number-columns-spanned">4</xsl:attribute>
+                            </xsl:if>
+                            <xsl:apply-templates select="ead:did" mode="dsc"/>
+                            <xsl:apply-templates mode="dsc" select="*[not(self::ead:did) and
                                 not(self::ead:c) and not(self::ead:c02) and not(self::ead:c03) and
                                 not(self::ead:c04) and not(self::ead:c05) and not(self::ead:c06) and not(self::ead:c07)
-                                and not(self::ead:c08) and not(self::ead:c09) and not(self::ead:c10) and not(self::ead:c11) and not(self::ead:c12)]"
-                        />
-                    </fo:table-cell>
-                    <fo:table-cell>
-                        <fo:block margin="4pt 0">
-                            <xsl:value-of select="ead:did/ead:container[1]/@type"/>
-                            <xsl:text> </xsl:text>
-                            <xsl:value-of select="ead:did/ead:container[1]"/>
-                        </fo:block>
-                    </fo:table-cell>
-                    <fo:table-cell>
-                        <fo:block margin="4pt 0">
-                            <xsl:value-of select="ead:did/ead:container[2]/@type"/>
-                            <xsl:text> </xsl:text>
-                            <xsl:value-of select="ead:did/ead:container[2]"/>
-                        </fo:block>
-                    </fo:table-cell>
-                    <fo:table-cell>
-                        <fo:block margin="4pt 0">
-                            <xsl:value-of select="ead:did/ead:container[3]/@type"/>
-                            <xsl:text> </xsl:text>
-                            <xsl:value-of select="ead:did/ead:container[3]"/>
-                        </fo:block>
-                    </fo:table-cell>
-                </fo:table-row>
-            </xsl:otherwise>
-        </xsl:choose>
+                                and not(self::ead:c08) and not(self::ead:c09) and not(self::ead:c10) and not(self::ead:c11) and not(self::ead:c12)]"/>
+                        </fo:table-cell>
+                    </fo:table-row>
+                    <!-- Groups instances by label attribute, the way they are grouped in ArchivesSpace -->
+                    <xsl:for-each-group select="ead:did/ead:container" group-starting-with=".[@label]">
+                        <fo:table-row keep-with-next.within-page="always">
+                            <xsl:apply-templates select="current-group()"/>
+                            <xsl:choose>
+                                <xsl:when test="count(current-group()) &lt; 2">
+                                    <fo:table-cell><fo:block/></fo:table-cell>
+                                    <fo:table-cell><fo:block/></fo:table-cell>
+                                </xsl:when>
+                                <xsl:when test="count(current-group()) &lt; 3">
+                                    <fo:table-cell><fo:block/></fo:table-cell>
+                                </xsl:when>
+                            </xsl:choose>
+                        </fo:table-row>
+                    </xsl:for-each-group>
+                </xsl:when>
+                <!-- For finding aids with no @label attribute, only accounts for three containers -->
+                <xsl:otherwise>
+                    <fo:table-row border-top="1px solid #ccc">
+                        <fo:table-cell margin-left="{$clevelMargin}"  padding-top="4pt" number-rows-spanned="{count(ead:did/ead:container[@label]) + 1}">
+                            <xsl:apply-templates select="ead:did" mode="dsc"/>
+                            <xsl:apply-templates mode="dsc" select="*[not(self::ead:did) and
+                                not(self::ead:c) and not(self::ead:c02) and not(self::ead:c03) and
+                                not(self::ead:c04) and not(self::ead:c05) and not(self::ead:c06) and not(self::ead:c07)
+                                and not(self::ead:c08) and not(self::ead:c09) and not(self::ead:c10) and not(self::ead:c11) and not(self::ead:c12)]"/>
+                        </fo:table-cell>
+                        <fo:table-cell>
+                            <fo:block margin="4pt 0"><xsl:value-of select="ead:did/ead:container[1]/@type"/><xsl:text> </xsl:text><xsl:value-of select="ead:did/ead:container[1]"/></fo:block>
+                        </fo:table-cell>
+                        <fo:table-cell>
+                            <fo:block margin="4pt 0"><xsl:value-of select="ead:did/ead:container[2]/@type"/><xsl:text> </xsl:text><xsl:value-of select="ead:did/ead:container[2]"/></fo:block>
+                        </fo:table-cell>
+                        <fo:table-cell>
+                            <fo:block margin="4pt 0"><xsl:value-of select="ead:did/ead:container[3]/@type"/><xsl:text> </xsl:text><xsl:value-of select="ead:did/ead:container[3]"/></fo:block>
+                        </fo:table-cell>
+                    </fo:table-row>
+                </xsl:otherwise>
+            </xsl:choose>
         <!-- Calls child components -->
-        <xsl:apply-templates
-            select="ead:c | ead:c01 | ead:c02 | ead:c03 | ead:c04 | ead:c05 | ead:c06 | ead:c07 | ead:c08 | ead:c09 | ead:c10 | ead:c11 | ead:c12"
-        />
+        <xsl:apply-templates select="ead:c | ead:c01 | ead:c02 | ead:c03 | ead:c04 | ead:c05 | ead:c06 | ead:c07 | ead:c08 | ead:c09 | ead:c10 | ead:c11 | ead:c12"/>
     </xsl:template>
     <!-- Named template to generate table headers -->
     <xsl:template name="tableHeaders">
-        <fo:table-row background-color="#f7f7f9" border-bottom="1px dotted #ccc"
-            border-top="1pt solid #ccc">
+        <fo:table-row background-color="#f7f7f9" border-bottom="1px dotted #ccc" border-top="1pt solid #ccc">
             <fo:table-cell>
-                <fo:block font-weight="bold" padding="2pt"> Title/Description </fo:block>
+                <fo:block font-weight="bold" padding="2pt">
+                    Title/Description
+                </fo:block>
             </fo:table-cell>
             <fo:table-cell number-columns-spanned="3">
-                <fo:block font-weight="bold" padding="2pt"> Instances </fo:block>
+                <fo:block font-weight="bold" padding="2pt">
+                    Instances
+                </fo:block>
             </fo:table-cell>
         </fo:table-row>
     </xsl:template>
     <!-- Formats did containers -->
     <xsl:template match="ead:container">
         <fo:table-cell>
-            <fo:block margin="4pt 0">
-                <xsl:value-of select="@type"/>
-                <xsl:text> </xsl:text>
-                <xsl:value-of select="."/>
-            </fo:block>
+            <fo:block margin="4pt 0"><xsl:value-of select="@type"/><xsl:text> </xsl:text><xsl:value-of select="."/></fo:block>
         </fo:table-cell>
     </xsl:template>
 
     <!-- Series titles -->
     <xsl:template match="ead:did" mode="dscSeriesTitle">
-        <fo:block font-weight="bold" font-size="14" margin-bottom="0" margin-top="4"
-            id="{local:buildID(parent::*)}">
+        <fo:block font-weight="bold" font-size="14" margin-bottom="0" margin-top="4" id="{local:buildID(parent::*)}">
             <!-- Uncomment the following to add 'Series' to series titles  -->
             <!--
             <xsl:if test="ead:unitid">
@@ -1729,14 +1514,12 @@
             </xsl:if>
             -->
             <xsl:apply-templates select="ead:unittitle"/>
-            <xsl:if
-                test="(string-length(ead:unittitle[1]) &gt; 1) and (string-length(ead:unitdate[1]) &gt; 1)"
-                >, </xsl:if>
+            <xsl:if test="(string-length(ead:unittitle[1]) &gt; 1) and (string-length(ead:unitdate[1]) &gt; 1)">, </xsl:if>
             <xsl:for-each select="ead:unitdate">
-                <xsl:apply-templates select="." mode="did"/>
-                <xsl:if test="position() != last()">
-                    <xsl:text>, </xsl:text>
-                </xsl:if>
+              <xsl:apply-templates select="." mode="did"/>
+              <xsl:if test="position()!=last()">
+				            <xsl:text>, </xsl:text>
+              </xsl:if>
             </xsl:for-each>
         </fo:block>
     </xsl:template>
@@ -1761,24 +1544,23 @@
     <!-- Unittitles and all other clevel elements -->
     <xsl:template match="ead:did" mode="dsc">
         <fo:block margin-bottom="0">
-<!-- FOX: display the unit id -->
+
+            <!-- FOX: display the unit id -->
             <xsl:if test="(string-length(ead:unitid) &gt; 0)">
                 <fo:inline font-style="italic">
                     <xsl:value-of select="ead:unitid"/>
                     <xsl:text>: </xsl:text>
                 </fo:inline>
             </xsl:if>
+            
             <xsl:apply-templates select="ead:unittitle"/>
-            <xsl:if
-                test="(string-length(ead:unittitle[1]) &gt; 1) and (string-length(ead:unitdate[1]) &gt; 1)"
-                >, </xsl:if>
+            <xsl:if test="(string-length(ead:unittitle[1]) &gt; 1) and (string-length(ead:unitdate[1]) &gt; 1)">, </xsl:if>
             <xsl:for-each select="ead:unitdate">
-                <xsl:apply-templates select="." mode="did"/>
-                <xsl:if test="position() != last()">
-                    <xsl:text>, </xsl:text>
-                </xsl:if>
+              <xsl:apply-templates select="." mode="did"/>
+              <xsl:if test="position()!=last()">
+				            <xsl:text>, </xsl:text>
+              </xsl:if>
             </xsl:for-each>
-
         </fo:block>
         <fo:block margin-bottom="4pt" margin-top="0">
             <xsl:apply-templates select="ead:repository" mode="dsc"/>
@@ -1797,67 +1579,53 @@
     <!-- Formats unitdates -->
     <xsl:template match="ead:unitdate[@type = 'bulk']" mode="did">
         <xsl:text>(</xsl:text>
-        <xsl:apply-templates/>
+          <xsl:apply-templates/>
         <xsl:text>)</xsl:text>
     </xsl:template>
-    <xsl:template match="ead:unitdate" mode="did">
-        <xsl:apply-templates/>
-    </xsl:template>
+    <xsl:template match="ead:unitdate" mode="did"><xsl:apply-templates/></xsl:template>
 
     <!-- Special formatting for elements in the collection inventory list -->
-    <xsl:template
-        match="
-            ead:repository | ead:origination | ead:unitid
-            | ead:physdesc | ead:physloc | ead:langmaterial | ead:materialspec | ead:container
-            | ead:abstract | ead:note"
-        mode="dsc">
+    <xsl:template match="ead:repository | ead:origination | ead:unitid
+        | ead:physdesc | ead:physloc | ead:langmaterial | ead:materialspec | ead:container
+        | ead:abstract | ead:note" mode="dsc">
         <xsl:if test="normalize-space()">
-            <fo:block xsl:use-attribute-sets="smpDsc">
-                <fo:inline text-decoration="underline">
-                    <xsl:choose>
-                        <!-- Test for label attribute used by origination element -->
-                        <xsl:when test="@label">
-                            <xsl:value-of
-                                select="concat(upper-case(substring(@label, 1, 1)), substring(@label, 2))"/>
-                            <xsl:if test="@type"> [<xsl:value-of select="@type"/>]</xsl:if>
-                            <xsl:if test="self::ead:origination">
-                                <xsl:choose>
-                                    <xsl:when
-                                        test="ead:persname[@role != ''] and contains(ead:persname/@role, ' (')"
-                                        > - <xsl:value-of
-                                            select="substring-before(ead:persname/@role, ' (')"/>
-                                    </xsl:when>
-                                    <xsl:when test="ead:persname[@role != '']"> - <xsl:value-of
-                                            select="ead:persname/@role"/>
-                                    </xsl:when>
-                                    <xsl:otherwise/>
-                                </xsl:choose>
-                            </xsl:if>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:value-of select="local:tagName(.)"/>
-                            <!-- Test for type attribute used by unitdate -->
-                            <xsl:if test="@type"> [<xsl:value-of select="@type"/>]</xsl:if>
-                        </xsl:otherwise>
-                    </xsl:choose></fo:inline>: <xsl:apply-templates/>
-                <!-- Test for certainty attribute used by unitdate -->
-                <xsl:if test="@certainty">
-                    <fo:inline font-style="italic"> (<xsl:value-of select="@certainty"
-                        />)</fo:inline></xsl:if>
-            </fo:block>
+        <fo:block xsl:use-attribute-sets="smpDsc">
+            <fo:inline text-decoration="underline">
+            <xsl:choose>
+                <!-- Test for label attribute used by origination element -->
+                <xsl:when test="@label">
+                    <xsl:value-of select="concat(upper-case(substring(@label,1,1)),substring(@label,2))"></xsl:value-of>
+                    <xsl:if test="@type"> [<xsl:value-of select="@type"/>]</xsl:if>
+                    <xsl:if test="self::ead:origination">
+                        <xsl:choose>
+                            <xsl:when test="ead:persname[@role != ''] and contains(ead:persname/@role,' (')">
+                                - <xsl:value-of select="substring-before(ead:persname/@role,' (')"/>
+                            </xsl:when>
+                            <xsl:when test="ead:persname[@role != '']">
+                                - <xsl:value-of select="ead:persname/@role"/>
+                            </xsl:when>
+                            <xsl:otherwise/>
+                        </xsl:choose>
+                    </xsl:if>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="local:tagName(.)"/>
+                    <!-- Test for type attribute used by unitdate -->
+                    <xsl:if test="@type"> [<xsl:value-of select="@type"/>]</xsl:if>
+                </xsl:otherwise>
+            </xsl:choose></fo:inline>: <xsl:apply-templates/>
+            <!-- Test for certainty attribute used by unitdate -->
+            <xsl:if test="@certainty" > <fo:inline font-style="italic"> (<xsl:value-of select="@certainty"/>)</fo:inline></xsl:if>
+        </fo:block>
         </xsl:if>
     </xsl:template>
-    <xsl:template
-        match="
-            ead:relatedmaterial | ead:separatedmaterial | ead:accessrestrict | ead:userestrict |
-            ead:custodhist | ead:accruals | ead:altformavail | ead:acqinfo |
-            ead:processinfo | ead:appraisal | ead:originalsloc"
-        mode="dsc">
+    <xsl:template match="ead:relatedmaterial | ead:separatedmaterial | ead:accessrestrict | ead:userestrict |
+        ead:custodhist | ead:accruals | ead:altformavail | ead:acqinfo |
+        ead:processinfo | ead:appraisal | ead:originalsloc" mode="dsc">
         <xsl:if test="child::*">
             <fo:block xsl:use-attribute-sets="smpDsc">
-                <fo:inline text-decoration="underline"><xsl:value-of select="local:tagName(.)"
-                    />:</fo:inline>
-                <xsl:apply-templates select="child::*[not(ead:head)]"/>
+                <fo:inline text-decoration="underline"><xsl:value-of select="local:tagName(.)"/>:</fo:inline>
+            <xsl:apply-templates select="child::*[not(ead:head)]"/>
             </fo:block>
         </xsl:if>
     </xsl:template>
@@ -1868,8 +1636,7 @@
         </fo:list-block>
     </xsl:template>
     <xsl:template match="ead:controlaccess" mode="dsc">
-        <fo:block xsl:use-attribute-sets="smpDsc" text-decoration="underline"><xsl:value-of
-                select="local:tagName(.)"/>:</fo:block>
+        <fo:block xsl:use-attribute-sets="smpDsc" text-decoration="underline"><xsl:value-of select="local:tagName(.)"/>:</fo:block>
         <fo:list-block xsl:use-attribute-sets="smpDsc">
             <xsl:apply-templates/>
         </fo:list-block>
@@ -1911,18 +1678,16 @@
         </xsl:variable>
         <fo:block xsl:use-attribute-sets="smpDsc">
             <fo:inline text-decoration="underline">
-                <xsl:choose>
-                    <!-- Test for label attribute used by origination element -->
-                    <xsl:when test="@label">
-                        <xsl:value-of
-                            select="concat(upper-case(substring(@label, 1, 1)), substring(@label, 2))"
-                        />
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:value-of select="local:tagName(.)"/>
-                    </xsl:otherwise>
-                </xsl:choose></fo:inline>: <fo:basic-link external-destination="url('{@*:href}')"
-                xsl:use-attribute-sets="ref">
+             <xsl:choose>
+                 <!-- Test for label attribute used by origination element -->
+                 <xsl:when test="@label">
+                     <xsl:value-of select="concat(upper-case(substring(@label,1,1)),substring(@label,2))"></xsl:value-of>
+                 </xsl:when>
+                 <xsl:otherwise>
+                     <xsl:value-of select="local:tagName(.)"/>
+                 </xsl:otherwise>
+             </xsl:choose></fo:inline>:
+            <fo:basic-link external-destination="url('{@*:href}')" xsl:use-attribute-sets="ref">
                 <xsl:value-of select="$title"/>
             </fo:basic-link>
         </fo:block>

--- a/backend/model/harvard_ead_exporter.rb
+++ b/backend/model/harvard_ead_exporter.rb
@@ -284,7 +284,7 @@ nopara = "NOPARA:" + item
       atts['xlink:actuate'] = file_version['xlink_actuate_attribute'] || 'onRequest'
       atts['xlink:show'] = file_version['xlink_show_attribute'] || 'new'
       atts['xlink:role'] = file_version['use_statement'] if file_version['use_statement']
-      atts['xlink:href'] = file_version['file_uri'] 
+      atts['xlink:href'] = file_version['file_uri'].strip 
       atts['xlink:audience'] = get_audience_flag_for_file_version(file_version)
       xml.dao(atts) {
         xml.daodesc{ sanitize_mixed_content(content, xml, fragments, true) } if content
@@ -300,7 +300,7 @@ nopara = "NOPARA:" + item
 	  showAtt    = file_version['xlink_show_attribute']
 	  actuateAtt = file_version['xlink_actuate_attribute']
           atts['xlink:type'] = 'locator'
-          atts['xlink:href'] = file_version['file_uri'] 
+          atts['xlink:href'] = file_version['file_uri'].strip 
           atts['xlink:role'] = file_version['use_statement'] if file_version['use_statement']
           atts['xlink:title'] = file_version['caption'] if file_version['caption']
           atts['xlink:audience'] = get_audience_flag_for_file_version(file_version)

--- a/backend/model/harvard_ead_exporter.rb
+++ b/backend/model/harvard_ead_exporter.rb
@@ -4,6 +4,17 @@ require 'securerandom'
 class EADSerializer < ASpaceExport::Serializer
   serializer_for :ead
 
+  # backported from 3.1.0 -> 3.0.2
+  # ANW-669: Fix for attributes in mixed content causing errors when validating against the EAD schema.
+  # If content looks like it contains a valid XML element with an attribute from the expected list,
+  # then replace the attribute like " foo=" with " xlink:foo=".
+  def add_xlink_prefix(content)
+    %w{ actuate arcrole from href role show title to}.each do |xa|
+      content.gsub!(/ #{xa}=/) {|match| " xlink:#{match.strip}"} if content =~ / #{xa}=/
+    end
+    content
+  end
+
   def xml_errors(content)
     # there are message we want to ignore. annoying that java xml lib doesn't
     # use codes like libxml does...


### PR DESCRIPTION
Adds `.strip` to `file_uri` values on EAD export, which makes it more amenable to FOP's attribute handling.